### PR TITLE
[abseil-cpp] Bump to 20230802.1

### DIFF
--- a/rpm/abseil-cpp.spec
+++ b/rpm/abseil-cpp.spec
@@ -1,5 +1,5 @@
 Name:           abseil-cpp
-Version:        20230125.0
+Version:        20230802.1
 Release:        1
 Summary:        C++ Common Libraries
 


### PR DESCRIPTION
This proposes a version bump to the latest LTS release.

20230125.3 is a minimum required version for building protobuf v21 and v25, a
bump of which I will propose in another PR shortly.

Reason is that several packages (e.g. on OBS/Chum) are starting to require newer
protobuf versions.

References:

 - Supeseeded PR: https://github.com/sailfishos/abseil-cpp/pull/1
 - Protobuf LTS Overview: https://protobuf.dev/support/version-support/
 - Test builds of these changes at OBS: https://build.sailfishos.org/project/monitor/home:nephros:sailfishos:pr

